### PR TITLE
Update traefik filter expression

### DIFF
--- a/examples/jails/traefik/filter.d/traefik-auth.conf
+++ b/examples/jails/traefik/filter.d/traefik-auth.conf
@@ -1,3 +1,3 @@
 [Definition]
-failregex = ^<HOST> \- \S+ \[.*\] \"[A-Z]+ .+\" 4(01|03|07|22|23|29) .+$
+failregex = ^<HOST> \- \S+ \[\] \"[A-Z]+ .+\" 4(01|03|07|22|23|29) .+$
 ignoreregex =

--- a/examples/jails/traefik/filter.d/traefik-auth.conf
+++ b/examples/jails/traefik/filter.d/traefik-auth.conf
@@ -1,3 +1,3 @@
 [Definition]
-failregex = ^<HOST> \- \S+ \[\] \"(GET|POST|HEAD) .+\" 401 .+$
+failregex = ^<HOST> \- \S+ \[.*\] \"[A-Z]+ .+\" 4(01|03|07|22|23|29) .+$
 ignoreregex =


### PR DESCRIPTION
I had problems with original expression. Traefik writes log date between
brackets (`[]`), and that regex wants no content inside them.

Also, I propose to include any HTTP method and some other 4xx status
codes. For example, I'm using Portainer behind Traefik proxy, and it is
returning `422` status code on login failure.