### PR TITLE
Fixes #23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk --update --no-cache add \
     tzdata \
     wget \
     whois \
+    kmod \
   && cd /tmp \
   && curl -SsOL https://github.com/fail2ban/fail2ban/archive/${FAIL2BAN_VERSION}.zip \
   && unzip ${FAIL2BAN_VERSION}.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk --update --no-cache add \
     ipset \
     iptables \
     ip6tables \
+    kmod \
     python3 \
     python3-dev \
     py-setuptools \
@@ -29,7 +30,6 @@ RUN apk --update --no-cache add \
     tzdata \
     wget \
     whois \
-    kmod \
   && cd /tmp \
   && curl -SsOL https://github.com/fail2ban/fail2ban/archive/${FAIL2BAN_VERSION}.zip \
   && unzip ${FAIL2BAN_VERSION}.zip \


### PR DESCRIPTION
This adds the necessary linux kernel utilities for ipv6 addresses to be successfully banned.