### PR TITLE
Only populate AuthUser/Pass in ssmtp.conf if defined in ENV

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,11 +30,16 @@ else
 mailhub=${SSMTP_HOST}:${SSMTP_PORT}
 hostname=${SSMTP_HOSTNAME}
 FromLineOverride=YES
-AuthUser=${SSMTP_USER}
-AuthPass=${SSMTP_PASSWORD}
 UseTLS=${SSMTP_TLS}
 UseSTARTTLS=${SSMTP_TLS}
 EOL
+  # Authentication to SMTP server is optional.
+  if [ -n "$SSMTP_USER" ] ; then
+    cat >> /etc/ssmtp/ssmtp.conf <<EOL
+AuthUser=${SSMTP_USER}
+AuthPass=${SSMTP_PASSWORD}
+EOL
+  fi
 fi
 unset SSMTP_HOST
 unset SSMTP_USER


### PR DESCRIPTION
My SMTP server is local and doesn't require authentication, so I omit the environment variables SSMTP_AUTH and SSMTP_PASSWORD. The entrypoint.sh script writes out ssmtp.conf with empty authentication settings:

    AuthUser=
    AuthPass=

However ssmtp doesn't ignore these settings when the values are empty and instead attempts to authenticate with empty credentials resulting in the following error:

    2019-09-16 12:48:05,189 fail2ban.utils          [1]: ERROR   7f12e1b55cf0 -- stderr: "sendmail: Server didn't like our AUTH LOGIN (504 5.3.3 AUTH mechanism LOGIN not available)"

This fix changes entrypoint.sh so it only populates AuthUser/Pass if SSMTP_AUTH has been defined in the environment.

Thanks for this docker image. Very useful!