### PR TITLE
Add support for non-STARTTLS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Image: crazymax/fail2ban:latest
 * `SSMTP_USER`: SMTP username
 * `SSMTP_PASSWORD`: SMTP password
 * `SSMTP_TLS`: SSL/TLS (default `NO`)
+* `SSMTP_STARTTLS`: STARTTLS (default `NO`)
 
 ### Volumes
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ F2B_IPTABLES_CHAIN=${F2B_IPTABLES_CHAIN:-DOCKER-USER}
 SSMTP_PORT=${SSMTP_PORT:-25}
 SSMTP_HOSTNAME=${SSMTP_HOSTNAME:-$(hostname -f)}
 SSMTP_TLS=${SSMTP_TLS:-NO}
+SSMTP_STARTTLS=${SSMTP_STARTTLS:-NO}
 
 # Timezone
 echo "Setting timezone to ${TZ}..."
@@ -26,7 +27,7 @@ mailhub=${SSMTP_HOST}:${SSMTP_PORT}
 hostname=${SSMTP_HOSTNAME}
 FromLineOverride=YES
 UseTLS=${SSMTP_TLS}
-UseSTARTTLS=${SSMTP_TLS}
+UseSTARTTLS=${SSMTP_STARTTLS}
 EOL
   # Authentication to SMTP server is optional.
   if [ -n "$SSMTP_USER" ] ; then


### PR DESCRIPTION
This PR adds support for non-STARTTLS connections by allowing to configure the `UseSTARTTLS` setting via a separate `SSMTP_STARTTLS` environment variable. In such cases (e.g. HostGator) the container cannot send email notifications, due to the fact that currently it is not possible to initiate SSL/TLS connections without using `STARTTLS`.