### PR TITLE
Add grep to improve nftables compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG FAIL2BAN_VERSION
 RUN apk --update --no-cache add \
     bash \
     curl \
+    grep \
     ipset \
     iptables \
     ip6tables \


### PR DESCRIPTION
Fail2ban uses `grep -P` for some nftables commands, see https://github.com/fail2ban/fail2ban/blob/master/config/action.d/nftables.conf#L56. 
Busybox' grep doesn't have the -P option, so adding GNU grep should solve the issue. 

Resolves #101.