### PR TITLE
writing the log to a file and reading it to stdout by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG FAIL2BAN_VERSION=1.0.2
-ARG ALPINE_VERSION=3.16
+ARG ALPINE_VERSION=3.17
 
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS fail2ban-src
 RUN apk add --no-cache git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,4 +100,6 @@ for filter in ${filters}; do
   ln -sf "/data/filter.d/${filter}" "/etc/fail2ban/filter.d/"
 done
 
+tail -f ${F2B_LOG_TARGET} &
+
 exec "$@"

--- a/examples/compose/fail2ban.env
+++ b/examples/compose/fail2ban.env
@@ -1,6 +1,6 @@
 TZ=Europe/Paris
 
-F2B_LOG_TARGET=STDOUT
+F2B_LOG_TARGET=/data/fail2ban.log
 F2B_LOG_LEVEL=INFO
 F2B_DB_PURGE_AGE=1d
 


### PR DESCRIPTION
For such a jail as [recidive](https://github.com/fail2ban/fail2ban/blob/master/config/filter.d/recidive.conf), it is necessary to [read the log file](https://github.com/fail2ban/fail2ban/blob/432e7e1e93936f09e349e80d94254e5f43d0cc8a/config/jail.conf#L824) fail2ban in order to be able to analyze repeated violations. I suggest writing a log to a file by default, but at the same time, by default, it should also be written to the docker log.

It may require adjustments, but the idea is something like this.

I checked it with version 3.17 - everything works fine.

![изображение](https://user-images.githubusercontent.com/37277056/209464914-248f911a-e231-46ea-92ee-1141349ab166.png)
