### PR TITLE
[Fix #181] add delay of 2 seconds to prevent trying to send mail before msmtpd is ready

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,4 +69,7 @@ fi
 iptables -V
 nft -v
 
+# add small delay to avoid trying to send mail before msmtpd is ready
+sleep 2
+
 exec "$@"


### PR DESCRIPTION
I propose this workaround (testing successfully on my side).
I think that a nicer way would be to use healthcheck (but I do not know how to implement it properly for msmtpd)

Feel free to reject it if you find this workaround hugly (as it is not a one I am proud of ;-)  )