### PR TITLE
added py3-setuptools as a runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,13 @@ RUN --mount=from=src,target=/tmp/fail2ban,rw \
     python3 \
     py3-dnspython \
     py3-inotify \
+    py3-setuptools \
     tzdata \
     wget \
     whois \
   && apk add --no-cache -t build-dependencies \
     build-base \
     py3-pip \
-    py3-setuptools \
     python3-dev \
   && cd /tmp/fail2ban \
   && 2to3 -w --no-diffs bin/* fail2ban \


### PR DESCRIPTION
The change here is a workaround for
```
ERROR   Backend 'pyinotify' failed to initialize due to No module named 'distutils'
```

Similar issue has been raised for systemd backend https://github.com/fail2ban/fail2ban/issues/3787.

With the newer release setuptools can be fully removed (https://github.com/fail2ban/fail2ban/issues/3787#issuecomment-2213618204, also tested on the fail2ban master branch)